### PR TITLE
Get code to build and test successfully on JDK9+

### DIFF
--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -84,6 +84,18 @@ under the License.
             <version>${camel.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+          <version>${jaxb.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
+          <version>${javax.activation.version}</version>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/collections/pom.xml
+++ b/collections/pom.xml
@@ -46,6 +46,11 @@ under the License.
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/collections/src/main/java/org/apache/tamaya/collections/ItemTokenizer.java
+++ b/collections/src/main/java/org/apache/tamaya/collections/ItemTokenizer.java
@@ -50,8 +50,7 @@ final class ItemTokenizer {
      */
     public static List<String> split(String value, ConversionContext context){
         return split(value, ConfigurationProvider.getConfiguration().getOrDefault(
-                '_' + context.getKey()+ "" +
-                        "item-separator", ","));
+                '_' + context.getKey() + ".item-separator", ","));
     }
 
     /**

--- a/collections/src/test/resources/META-INF/javaconfiguration.properties
+++ b/collections/src/test/resources/META-INF/javaconfiguration.properties
@@ -65,7 +65,7 @@ _currency-list.collection-type=List
 
 parser-list=a,b,c
 _parser-list.collection-type=List
-_parser-list.item-converter=org.apache.tamaya.collections.MyUpperCaseConverter
+_parser-list.item-converters=org.apache.tamaya.collections.MyUpperCaseConverter
 
 redefined-map=0==none | 1==single | 2==any
 _redefined-map.map-entry-separator===

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@ under the License.
         <johnzon.version>0.9-incubating</johnzon.version>
         <junit.version>4.12</junit.version>
         <assertj.version>3.8.0</assertj.version>
+        <surefire.version>2.21.0</surefire.version>
+
+        <!-- Java EE modules for compiling on JDK9+ -->
+        <jaxb.version>2.3.0</jaxb.version>
+        <javax.activation.version>1.2.0</javax.activation.version>
 
         <!-- Dependency and plugin relate version properties go here -->
         <arquillian.version>1.1.7.Final</arquillian.version>
@@ -67,11 +72,11 @@ under the License.
         <asciidoctor-diagramm.version>1.2.1</asciidoctor-diagramm.version>
         <asciidoctorj.version>1.5.6</asciidoctorj.version>
         <checkstyle.version>2.15</checkstyle.version>
-        <enforcer.version>1.4.1</enforcer.version>
+        <enforcer.version>3.0.0-M1</enforcer.version>
         <gem.plugin>1.0.7</gem.plugin>
         <sources.plugin>3.0.1</sources.plugin>
         <hamcrest.version>2.0.0.0</hamcrest.version>
-        <javadoc.version>2.10.4</javadoc.version>
+        <javadoc.version>3.0.0</javadoc.version>
         <!-- Must/should match the JRuby version used by AsciidoctorJ -->
         <jruby.version>1.7.26</jruby.version>
         <findbugs.version>3.0.4</findbugs.version>
@@ -450,6 +455,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
                     <inherited>true</inherited>
                 </plugin>
 
@@ -630,6 +636,19 @@ under the License.
                         </configuration>
                     </execution>
                 </executions>
+                <!-- compiling on JDK 9+ requires these Java EE modules -->
+                <dependencies>
+                  <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <version>${jaxb.version}</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                    <version>${javax.activation.version}</version>
+                  </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -657,6 +676,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${enforcer.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -685,6 +705,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${javadoc.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -701,6 +722,15 @@ under the License.
                     <source>${maven.compile.sourceLevel}</source>
                     <verbose>false</verbose>
                 </configuration>
+                <!-- compiling on JDK 10 requires a newer version of commons-lang3
+                     it should be possible to remove this once a newer javadoc plugin becomes available -->
+                <dependencies>
+                  <dependency>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                    <version>3.7</version>
+                  </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>

--- a/vertx/src/main/java/org/apache/tamaya/vertx/TamayaConfigurationProducer.java
+++ b/vertx/src/main/java/org/apache/tamaya/vertx/TamayaConfigurationProducer.java
@@ -87,7 +87,7 @@ public class TamayaConfigurationProducer extends AbstractConfiguredVerticle{
 
     /**
      * Registers a handler for accessing multiple configuration keys (input: String[] (Json),
-     * reply type: Map<String,String></String,String> (Json).
+     * reply type: {@code Map<String,String>} (Json).
      * @param address the event bus address to register.
      * @param eventBus the event bus.
      * @return the consumer registered.

--- a/vertx/src/test/java/org/apache/tamaya/vertx/TestInjectedVerticleTest.java
+++ b/vertx/src/test/java/org/apache/tamaya/vertx/TestInjectedVerticleTest.java
@@ -98,7 +98,6 @@ public class TestInjectedVerticleTest {
                         testContext.assertNotNull(reply.result().body());
                         Map<String,String> config = Json.decodeValue((String)reply.result().body(), Map.class);
                         Map<String,String> compareTo = ConfigurationProvider.getConfiguration().getProperties();
-                        testContext.assertEquals(config.size(), 3);
                         testContext.assertEquals(
                                     config.get("user.name"), System.getProperty("user.name"));
                         testContext.assertEquals(


### PR DESCRIPTION
This change updates the Tamaya sandbox code to make it build properly on JDK9+.

One issue I encountered was that, at present (under JDK 1.8), the test suite does not run, and there were two problems in the `collections` extension. The first issue related to a missing `.` character in the construction of the item separator value from the configuration. The second was, for a custom item converter, the code is expecting the value `.item-converters` but the test fixture was using `.item-converter`. There is no existing documentation that I saw indicating that it should be one way instead of the other, so I am assuming that it is correct in the code and incorrect in the test.

Another issue I encountered -- and this only happens under JDK10 -- is that in the `vertx` extension test, the filtered response from the JAVA environment entries varies. Under jdk8 and jdk9 this list includes `user.home`, `user.name` and `java.version`, but under jdk10, the response also includes `java.version.date`. And so the test that checks for three entries in the `Map` will fail. I simply removed that check.

And other than a simple javadoc fix (jdk10 is more strict about javadocs), this change is primarily about adding JavaEE modules as runtime dependencies.