### PR TITLE
Add Automatic-Module-Name metadata

### DIFF
--- a/apache-commons/bnd.bnd
+++ b/apache-commons/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.commons
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Commons Integration
 Bundle-SymbolicName: org.apache.tamaya.commons

--- a/camel/bnd.bnd
+++ b/camel/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.camel
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Camel Integration
 Bundle-SymbolicName: org.apache.tamaya.camel

--- a/collections/bnd.bnd
+++ b/collections/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.collections
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Collections Support
 Bundle-SymbolicName: org.apache.tamaya.collections

--- a/configjsr/bnd.bnd
+++ b/configjsr/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.jsr382
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - JSR 382
 Bundle-SymbolicName: org.apache.tamaya.jsr382

--- a/configured-sysprops/bnd.bnd
+++ b/configured-sysprops/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.sysprops
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - System Integration
 Bundle-SymbolicName: org.apache.tamaya.sysprops

--- a/consul/bnd.bnd
+++ b/consul/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.consul
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Consul
 Bundle-SymbolicName: org.apache.tamaya.consul

--- a/etcd/bnd.bnd
+++ b/etcd/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.etcd
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Etcd Config
 Bundle-SymbolicName: org.apache.tamaya.etcd

--- a/hazelcast/bnd.bnd
+++ b/hazelcast/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.hazelcast
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Hazelcast Config
 Bundle-SymbolicName: org.apache.tamaya.hazelcast

--- a/jodatime/bnd.bnd
+++ b/jodatime/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.jodatime
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Jodatime Converters
 Bundle-SymbolicName: org.apache.tamaya.jodatime

--- a/management/bnd.bnd
+++ b/management/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.management
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - JMX
 Bundle-SymbolicName: org.apache.tamaya.management

--- a/metamodel/bnd.bnd
+++ b/metamodel/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.metamodel
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Metamodel
 Bundle-SymbolicName: org.apache.tamaya.metamodel

--- a/propertysources/bnd.bnd
+++ b/propertysources/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.propertysources
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - More PropertySources
 Bundle-SymbolicName: org.apache.tamaya.propertysources

--- a/remote/bnd.bnd
+++ b/remote/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.remote
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Server Client
 Bundle-SymbolicName: org.apache.tamaya.remote

--- a/server/bnd.bnd
+++ b/server/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.server
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Server
 Bundle-SymbolicName: org.apache.tamaya.server

--- a/ui/base/bnd.bnd
+++ b/ui/base/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.ui
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - UI
 Bundle-SymbolicName: org.apache.tamaya.ui

--- a/ui/events/bnd.bnd
+++ b/ui/events/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.ui.events
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - UI (Events)
 Bundle-SymbolicName: org.apache.tamaya.ui.events

--- a/ui/mutableconfig/bnd.bnd
+++ b/ui/mutableconfig/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.ui.mutableconfig
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - UI (MutableConfig)
 Bundle-SymbolicName: org.apache.tamaya.ui.mutableconfig

--- a/uom/bnd.bnd
+++ b/uom/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.ui.uom
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - UoM
 Bundle-SymbolicName: org.apache.tamaya.ui.uom

--- a/usagetracker/bnd.bnd
+++ b/usagetracker/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.usagetracker
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Usagetracker
 Bundle-SymbolicName: org.apache.tamaya.usagetracker

--- a/validation/bnd.bnd
+++ b/validation/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.validation
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Validator
 Bundle-SymbolicName: org.apache.tamaya.validation

--- a/vertx/bnd.bnd
+++ b/vertx/bnd.bnd
@@ -9,6 +9,7 @@
 javac.source: 1.8
 javac.target: 1.8
 
+Automatic-Module-Name: org.apache.tamaya.vertx
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Vertx Integration
 Bundle-SymbolicName: org.apache.tamaya.vertx


### PR DESCRIPTION
Addresses TAMAYA-331

This adds bundle metadata for use with JDK9+
For each component, the assigned `Automatic-Module-Name` value is the same as the OSGi exported package.