### PR TITLE
Proposal: Change default key-value separator from :: to =

### DIFF
--- a/collections/src/main/java/org/apache/tamaya/collections/ItemTokenizer.java
+++ b/collections/src/main/java/org/apache/tamaya/collections/ItemTokenizer.java
@@ -91,7 +91,7 @@ final class ItemTokenizer {
      */
     public static String[] splitMapEntry(String mapEntry, ConversionContext context){
         return splitMapEntry(mapEntry, ConfigurationProvider.getConfiguration().getOrDefault(
-                '_' + context.getKey()+".map-entry-separator", "::"));
+                '_' + context.getKey()+".map-entry-separator", "="));
     }
 
     /**


### PR DESCRIPTION
I think this is more common. What do you think about that?