### PR TITLE
TAMAYA-273 Fix infinite recursion in metamodel

### DIFF
--- a/metamodel/src/main/java/org/apache/tamaya/metamodel/internal/DSLLoadingConfigurationProviderSpi.java
+++ b/metamodel/src/main/java/org/apache/tamaya/metamodel/internal/DSLLoadingConfigurationProviderSpi.java
@@ -90,9 +90,6 @@ public class DSLLoadingConfigurationProviderSpi implements ConfigurationProvider
         if(config==null){
             synchronized (LOCK) {
                 if(config==null){
-                    MetaConfiguration.configure();
-                }
-                if(config==null){
                     // load defaults
                     this.config = new DefaultConfiguration(
                             new DefaultConfigurationContextBuilder()

--- a/metamodel/src/test/java/org/apache/tamaya/metamodel/ext/IntegrationTest.java
+++ b/metamodel/src/test/java/org/apache/tamaya/metamodel/ext/IntegrationTest.java
@@ -42,8 +42,14 @@ public class IntegrationTest {
 
     @Test
     public void checkSystemLoads(){
-        assertThat(ConfigurationProvider.getConfiguration()).isNotNull();
-        System.out.println(ConfigurationProvider.getConfiguration());
+        Configuration defaultConfig = ConfigurationProvider.getConfiguration();
+        assertThat(defaultConfig).isNotNull();
+        
+        MetaConfiguration.configure();
+        Configuration defaultMetaConfig = ConfigurationProvider.getConfiguration();
+        assertThat(defaultMetaConfig).isNotNull();
+        
+        assertThat(defaultConfig).isNotEqualTo(defaultMetaConfig);
     }
 
     @Test


### PR DESCRIPTION
With the lazily loaded configuration in metamodel, the logic is
susceptible to an infinite recursion if any part of the configuration
setting does a getConfiguration in the middle.  The spi delegation logic
added getConfiguration logging to all static calls as part of
https://github.com/apache/incubator-tamaya/commit/5a130523ab7d3a9d33091b13f62db90ddb8fba5c which caused this module to infinitely recurse and fail.

This commit breaks the recursion cycle and extends the tests to be more precise.