### PR TITLE
TAMAYA-349: Ensure Tamaya builds on JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 jdk:
   - oraclejdk8
+  - oraclejdk9
+  - oraclejdk10
   - oraclejdk11
 #before_script:
 #  - pip install --user codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk9
+  - oraclejdk11
 #before_script:
 #  - pip install --user codecov
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@ under the License.
         <gem.plugin>1.0.7</gem.plugin>
         <sources.plugin>3.0.1</sources.plugin>
         <hamcrest.version>2.0.0.0</hamcrest.version>
-        <javadoc.version>3.0.0</javadoc.version>
+        <javadoc.version>3.0.1</javadoc.version>
         <!-- Must/should match the JRuby version used by AsciidoctorJ -->
         <jruby.version>1.7.26</jruby.version>
         <findbugs.version>3.0.4</findbugs.version>
@@ -319,7 +319,7 @@ under the License.
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.1</version>
+                    <version>0.8.2</version>
                 </plugin>
                 <plugin>
                     <groupId>de.saumya.mojo</groupId>


### PR DESCRIPTION
This updates the JaCoCo and Javadoc plugins so that Tamaya can be build on JDK 11.