### PR TITLE
TAMAYA-345 Associative array default separator to ':'

### DIFF
--- a/collections/src/main/java/org/apache/tamaya/collections/ItemTokenizer.java
+++ b/collections/src/main/java/org/apache/tamaya/collections/ItemTokenizer.java
@@ -91,7 +91,7 @@ final class ItemTokenizer {
      */
     public static String[] splitMapEntry(String mapEntry, ConversionContext context){
         return splitMapEntry(mapEntry, ConfigurationProvider.getConfiguration().getOrDefault(
-                '_' + context.getKey()+".map-entry-separator", "::"));
+                '_' + context.getKey()+".map-entry-separator", ":"));
     }
 
     /**

--- a/collections/src/test/java/org/apache/tamaya/collections/CollectionsBaseTests.java
+++ b/collections/src/test/java/org/apache/tamaya/collections/CollectionsBaseTests.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertNotNull;
 /**
  * Basic tests for Tamaya collection support. Relevant configs for this tests:
  * <pre>base.items=1,2,3,4,5,6,7,8,9,0
- * base.map=1::a, 2::b, 3::c, [4:: ]
+ * base.map=1:a, 2:b, 3:c, [4: ]
  * </pre>
  */
 public class CollectionsBaseTests {

--- a/collections/src/test/java/org/apache/tamaya/collections/CollectionsTypedReadOnlyTests.java
+++ b/collections/src/test/java/org/apache/tamaya/collections/CollectionsTypedReadOnlyTests.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.*;
 /**
  * Basic tests for Tamaya collection support. Relevant configs for this tests:
  * <pre>base.items=1,2,3,4,5,6,7,8,9,0
- * base.map=1::a, 2::b, 3::c, [4:: ]
+ * base.map=1:a, 2:b, 3:c, [4: ]
  * </pre>
  */
 public class CollectionsTypedReadOnlyTests {

--- a/collections/src/test/java/org/apache/tamaya/collections/CollectionsTypedTests.java
+++ b/collections/src/test/java/org/apache/tamaya/collections/CollectionsTypedTests.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Basic tests for Tamaya collection support. Relevant configs for this tests:
  * <pre>base.items=1,2,3,4,5,6,7,8,9,0
- * base.map=1::a, 2::b, 3::c, [4:: ]
+ * base.map=1:a, 2:b, 3:c, [4: ]
  * </pre>
  */
 public class CollectionsTypedTests {

--- a/collections/src/test/resources/META-INF/javaconfiguration.properties
+++ b/collections/src/test/resources/META-INF/javaconfiguration.properties
@@ -20,7 +20,7 @@
 
 # Config for base tests (no combination policy)
 base.items=1,2,3,4,5,6,7,8,9,0
-base.map=1::a, 2::b, 3::c, [4:: ]
+base.map=1:a, 2:b, 3:c, [4: ]
 
 # Config for tests with explcit implementation types
 typed2.arraylist=1,2,3,4,5,6,7,8,9,0
@@ -35,10 +35,10 @@ _typed2.hashset.read-only=false
 typed2.treeset=1,2,3,4,5,6,7,8,9,0
 _typed2.treeset.collection-type=TreeSet
 _typed2.treeset.read-only=false
-typed2.hashmap=1::a, 2::b, 3::c, [4:: ]
+typed2.hashmap=1:a, 2:b, 3:c, [4: ]
 _typed2.hashmap.collection-type=java.util.HashMap
 _typed2.hashmap.read-only=false
-typed2.treemap=1::a, 2::b, 3::c, [4:: ]
+typed2.treemap=1:a, 2:b, 3:c, [4: ]
 _typed2.treemap.collection-type=TreeMap
 _typed2.treemap.read-only=false
 
@@ -51,9 +51,9 @@ typed.hashset=1,2,3,4,5,6,7,8,9,0
 _typed.hashset.collection-type=HashSet
 typed.treeset=1,2,3,4,5,6,7,8,9,0
 _typed.treeset.collection-type=TreeSet
-typed.hashmap=1::a, 2::b, 3::c, [4:: ]
+typed.hashmap=1:a, 2:b, 3:c, [4: ]
 _typed.hashmap.collection-type=java.util.HashMap
-typed.treemap=1::a, 2::b, 3::c, [4:: ]
+typed.treemap=1:a, 2:b, 3:c, [4: ]
 _typed.treemap.collection-type=TreeMap
 
 # Config for advanced tests


### PR DESCRIPTION
See the discussion at https://issues.apache.org/jira/browse/TAMAYA-345 .  The plurality of popular languages currently declare maps using a single colon between key and value.  This brings tamaya's collections module in line with that.