### PR TITLE
Get the tests passing before 2018 ends.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -637,10 +637,10 @@ under the License.
 
 
         <plugins>
-            <plugin>
+           <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
-                <version>4.2.0</version>
+                <version>4.2.2</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -652,6 +652,9 @@ under the License.
                         <configuration>
                             <startLevel>80</startLevel>
                             <aggregateFeatures>true</aggregateFeatures>
+                            <excludedArtifactIds>
+                                <excludedArtifactId>tamaya-doc_alpha</excludedArtifactId>
+                            </excludedArtifactIds>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Tamaya-validator_alpha's dependency on tamaya-doc_alpha causes the Karaf plugin to try to read doc's target/classes directory as a jar file. Because of a weird corner case in the NIO update that Karaf did in v4.1.3 the exception that is caused during that read is uncaught instead of being converted to a warning.  This excludes that module from Karaf's plugin until I can get the exception turned back into a warning.

This also wraps the vertx test deployment in a blocking wrapper that makes sure the deployment completes before we try to test the eventBus calls.  I think this will reduce the changes of hitting an NPE, which I think happens when we send a message without having a deployment on the other side to receive it.