### PR TITLE
Clean up OSGi/Manifest metadata

### DIFF
--- a/apache-commons/bnd.bnd
+++ b/apache-commons/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.commons
 Import-Package: \

--- a/camel/bnd.bnd
+++ b/camel/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.camel
 Import-Package: \

--- a/configjsr/bnd.bnd
+++ b/configjsr/bnd.bnd
@@ -18,7 +18,7 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
 Bundle-DocURL: https://tamaya.incubator.apache.org
 Export-Package: \
 	org.apache.tamaya.jsr382,\

--- a/configured-sysprops/bnd.bnd
+++ b/configured-sysprops/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.sysprops
 Import-Package: \

--- a/documentation/bnd.bnd
+++ b/documentation/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.doc,\
     org.apache.tamaya.doc.spi

--- a/jodatime/bnd.bnd
+++ b/jodatime/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.jodatime
 Import-Package: \

--- a/management/bnd.bnd
+++ b/management/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.management
 Import-Package: \

--- a/metamodel/bnd.bnd
+++ b/metamodel/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.metamodel,\
     org.apache.tamaya.metamodel.dsl,\

--- a/pom.xml
+++ b/pom.xml
@@ -479,11 +479,33 @@ under the License.
                 </plugin>
 
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>1.4</version>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>create</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                        <shortRevisionLength>8</shortRevisionLength>
+                    </configuration>
+                </plugin>
+
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <configuration>
                         <archive>
+                            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                             <addMavenDescriptor>false</addMavenDescriptor>
+                            <manifest>
+                              <addDefaultImplementationEntries>false</addDefaultImplementationEntries>
+                            </manifest>
                             <manifestEntries>
                                 <Specification-Title>Apache ${project.name}</Specification-Title>
                                 <Specification-Version>${project.version}</Specification-Version>
@@ -492,7 +514,6 @@ under the License.
                                 <Implementation-Version>${project.version} ${buildNumber}</Implementation-Version>
                                 <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
                                 <SCM-Revision>${buildNumber}</SCM-Revision>
-                                <SCM-url>${project.scm.url}</SCM-url>
                             </manifestEntries>
                         </archive>
                     </configuration>
@@ -792,6 +813,10 @@ under the License.
                     <source>${maven.compile.sourceLevel}</source>
                     <target>${maven.compile.targetLevel}</target>
                 </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>

--- a/propertysources/bnd.bnd
+++ b/propertysources/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.propertysources
 Import-Package: \

--- a/remote/bnd.bnd
+++ b/remote/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.remote
 Import-Package: \

--- a/server/bnd.bnd
+++ b/server/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.server,\
     	org.apache.tamaya.server.spi

--- a/ui/base/bnd.bnd
+++ b/ui/base/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.ui,\
     org.apache.tamaya.ui.event,\

--- a/ui/events/bnd.bnd
+++ b/ui/events/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.ui.events
 Import-Package: \

--- a/ui/mutableconfig/bnd.bnd
+++ b/ui/mutableconfig/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.ui.mutableconfig
 Import-Package: \

--- a/uom/bnd.bnd
+++ b/uom/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.ui.uom
 Import-Package: \

--- a/usagetracker/bnd.bnd
+++ b/usagetracker/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.usagetracker,\
     org.apache.tamaya.usagetracker.spi

--- a/validation/bnd.bnd
+++ b/validation/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.validation,\
     org.apache.tamaya.validation.spi

--- a/vertx/bnd.bnd
+++ b/vertx/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.vertx
 Import-Package: \


### PR DESCRIPTION
Related to TAMAYA-331

Similar to https://github.com/apache/incubator-tamaya/pull/30, this cleans up the OSGi metadata, adding the `buildnumber-maven-plugin`, which appeared to be missing.