### PR TITLE
Update to non-alpha depedencies

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -58,7 +58,7 @@ under the License.
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-jaxrs_2.0_spec</artifactId>
-            <version>1.0-alpha-1</version>
+            <version>1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-jaxrs_2.0_spec</artifactId>
-            <version>1.0-alpha-1</version>
+            <version>1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/usagetracker/pom.xml
+++ b/usagetracker/pom.xml
@@ -71,8 +71,8 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-json_1.0_spec</artifactId>
-            <version>1.0-alpha-1</version>
+            <artifactId>geronimo-json_1.1_spec</artifactId>
+            <version>1.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This updates some dependencies from `alpha` versions to stable 1.x versions.

Note: the `javax.json` dependency is updated to the 1.1 artifact, since the 1.0 spec from geronimo only provides an `alpha` version for the 1.0 spec.