### PR TITLE
Remove duplicate import of tamaya-formats

### DIFF
--- a/hjson/pom.xml
+++ b/hjson/pom.xml
@@ -68,11 +68,6 @@ under the License.
             <artifactId>hjson</artifactId>
             <version>${hjson.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.tamaya.ext</groupId>
-            <artifactId>tamaya-formats</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
The `tamaya-formats` module is listed twice in the dependencies. This removes the extraneous one.