### PR TITLE
TAMAYA-380: Rename class to fix spelling

### DIFF
--- a/configjsr/src/main/java/org/apache/tamaya/jsr382/JavaConfigAdapterFactory.java
+++ b/configjsr/src/main/java/org/apache/tamaya/jsr382/JavaConfigAdapterFactory.java
@@ -162,7 +162,7 @@ public final class JavaConfigAdapterFactory {
      */
     public static <T> PropertyConverter<T> toPropertyConverter(Converter<T> converter, int priority) {
         if(converter instanceof JavaConfigConverterAdapter){
-            return PriorizedPropertyConverter.of(((JavaConfigConverterAdapter)converter).getPropertyConverter(), priority);
+            return PrioritizedPropertyConverter.of(((JavaConfigConverterAdapter)converter).getPropertyConverter(), priority);
         }
         return new TamayaPropertyConverterAdapter(converter);
     }

--- a/configjsr/src/main/java/org/apache/tamaya/jsr382/PrioritizedPropertyConverter.java
+++ b/configjsr/src/main/java/org/apache/tamaya/jsr382/PrioritizedPropertyConverter.java
@@ -27,21 +27,21 @@ import java.util.Objects;
  * A prioritized property converter.
  * @param <T> the property type
  */
-final class PriorizedPropertyConverter<T> implements PropertyConverter<T> {
+final class PrioritizedPropertyConverter<T> implements PropertyConverter<T> {
 
     private final PropertyConverter<T> delegate;
     private int priority;
 
-    public PriorizedPropertyConverter(PropertyConverter<T> propertyConverter, int priority) {
+    public PrioritizedPropertyConverter(PropertyConverter<T> propertyConverter, int priority) {
         this.priority = priority;
         this.delegate = Objects.requireNonNull(propertyConverter);
     }
 
     public static <T> PropertyConverter<T> of(PropertyConverter<T> propertyConverter, int priority) {
-        if(propertyConverter instanceof PriorizedPropertyConverter){
-            return ((PriorizedPropertyConverter)propertyConverter).setPriority(priority);
+        if(propertyConverter instanceof PrioritizedPropertyConverter){
+            return ((PrioritizedPropertyConverter)propertyConverter).setPriority(priority);
         }
-        return new PriorizedPropertyConverter<>(propertyConverter, priority);
+        return new PrioritizedPropertyConverter<>(propertyConverter, priority);
     }
 
     private PropertyConverter<T> setPriority(int priority) {
@@ -56,7 +56,7 @@ final class PriorizedPropertyConverter<T> implements PropertyConverter<T> {
 
     @Override
     public String toString() {
-        return "PriorizedPropertyConverter{" +
+        return "PrioritizedPropertyConverter{" +
                 "delegate=" + delegate +
                 ", priority=" + priority +
                 '}';


### PR DESCRIPTION
As this class relates to a prioritized property converter, it appears that it should be spelled `PrioritizedPropertyConverter`. This PR just changes the class name to fix the spelling error.