### PR TITLE
TAMAYA-379: Apply checkstyle rules to test code

### DIFF
--- a/buildtools/src/main/resources/checkstyle/suppressions.xml
+++ b/buildtools/src/main/resources/checkstyle/suppressions.xml
@@ -1,0 +1,25 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE suppressions PUBLIC
+     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<suppressions>
+  <suppress checks="JavadocType" files="src[/\\]test[/\\]java"/>
+  <suppress checks="MethodName" files="src[/\\]test[/\\]java"/>
+</suppressions>

--- a/configjsr/src/test/java/org/apache/tamaya/jsr382/BuildableConfigSource.java
+++ b/configjsr/src/test/java/org/apache/tamaya/jsr382/BuildableConfigSource.java
@@ -52,8 +52,12 @@ public class BuildableConfigSource implements ConfigSource{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         BuildableConfigSource that = (BuildableConfigSource) o;
 

--- a/configjsr/src/test/java/org/apache/tamaya/jsr382/JavaConfigAdapterTest.java
+++ b/configjsr/src/test/java/org/apache/tamaya/jsr382/JavaConfigAdapterTest.java
@@ -18,7 +18,10 @@
  */
 package org.apache.tamaya.jsr382;
 
-import org.apache.tamaya.*;
+import org.apache.tamaya.Configuration;
+import org.apache.tamaya.ConfigurationProvider;
+import org.apache.tamaya.ConfigurationSnapshot;
+import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConfigurationContext;
 import org.apache.tamaya.spi.PropertyConverter;
 import org.apache.tamaya.spi.PropertySource;
@@ -35,7 +38,7 @@ import javax.config.spi.ConfigSource;
 import javax.config.spi.Converter;
 import java.util.*;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JavaConfigAdapterTest {
     @Test

--- a/configjsr/src/test/java/org/apache/tamaya/jsr382/JavaConfigConfigProviderResolverTest.java
+++ b/configjsr/src/test/java/org/apache/tamaya/jsr382/JavaConfigConfigProviderResolverTest.java
@@ -25,7 +25,7 @@ import javax.config.spi.ConfigProviderResolver;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 24.03.17.

--- a/configjsr/src/test/java/org/apache/tamaya/jsr382/JavaConfigConfigProviderTest.java
+++ b/configjsr/src/test/java/org/apache/tamaya/jsr382/JavaConfigConfigProviderTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tamaya.jsr382;
 
-import org.apache.tamaya.ConfigurationProvider;
 import org.junit.Test;
 
 import javax.config.Config;

--- a/configjsr/src/test/java/org/apache/tamaya/jsr382/JavaConfigConfigTest.java
+++ b/configjsr/src/test/java/org/apache/tamaya/jsr382/JavaConfigConfigTest.java
@@ -26,7 +26,7 @@ import javax.config.spi.ConfigSource;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 24.03.17.

--- a/configjsr/src/test/java/org/apache/tamaya/jsr382/SmokeExamples.java
+++ b/configjsr/src/test/java/org/apache/tamaya/jsr382/SmokeExamples.java
@@ -22,7 +22,11 @@ import org.apache.tamaya.Configuration;
 import org.apache.tamaya.ConfigurationSnapshot;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.functions.ConfigurationFunctions;
-import org.apache.tamaya.spi.*;
+import org.apache.tamaya.spi.ConfigurationBuilder;
+import org.apache.tamaya.spi.ConversionContext;
+import org.apache.tamaya.spi.PropertyConverter;
+import org.apache.tamaya.spi.PropertySource;
+import org.apache.tamaya.spi.PropertyValue;
 
 import javax.config.Config;
 import javax.config.ConfigAccessor;

--- a/hjson/src/test/java/org/apache/tamaya/hjson/HJSONVisitorTest.java
+++ b/hjson/src/test/java/org/apache/tamaya/hjson/HJSONVisitorTest.java
@@ -32,61 +32,61 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class HJSONVisitorTest {
 
-	@Test
-	public void ensureJSONisParsedProperlyWithDifferentValueTypesFilteringOutEmptyValues() {
-		JsonObject startNode = new JsonObject().//
-				add("key.sub", "createValue").//
-				add("anotherKey", true).//
-				add("notAnotherKey", false).//
-				add("number", 4711).//
-				add("null", JsonValue.NULL).//
-				add("empty", "");
-		HJSONDataBuilder visitor = new HJSONDataBuilder("Test:ensureJSONisParsedProperlyWithDifferentValueTypesFilteringOutEmptyValues", startNode);
+    @Test
+    public void ensureJSONisParsedProperlyWithDifferentValueTypesFilteringOutEmptyValues() {
+        JsonObject startNode = new JsonObject().//
+                add("key.sub", "createValue").//
+                add("anotherKey", true).//
+                add("notAnotherKey", false).//
+                add("number", 4711).//
+                add("null", JsonValue.NULL).//
+                add("empty", "");
+        HJSONDataBuilder visitor = new HJSONDataBuilder("Test:ensureJSONisParsedProperlyWithDifferentValueTypesFilteringOutEmptyValues", startNode);
 
-		PropertyValue data = visitor.build();
-		assertThat(data).isNotNull();
+        PropertyValue data = visitor.build();
+        assertThat(data).isNotNull();
 
-		ObjectValue ov = data.toObjectValue();
-		assertThat(ov.getValues()).hasSize(6);
-		assertThat(data.toMap()).containsKeys("key.sub", "anotherKey", "notAnotherKey", "number", "null")
-		        .containsEntry("key.sub", "createValue")
+        ObjectValue ov = data.toObjectValue();
+        assertThat(ov.getValues()).hasSize(6);
+        assertThat(data.toMap()).containsKeys("key.sub", "anotherKey", "notAnotherKey", "number", "null")
+                .containsEntry("key.sub", "createValue")
                 .containsEntry("null", null)
                 .containsEntry("anotherKey", "true")
                 .doesNotContainEntry("empty", null);
-	}
+    }
 
-	@Test
-	public void parsingWorksOnEmptyObject() {
-		JsonObject startNode = new JsonObject();
+    @Test
+    public void parsingWorksOnEmptyObject() {
+        JsonObject startNode = new JsonObject();
 
-		Map<String, String> targetStore = new HashMap<>();
+        Map<String, String> targetStore = new HashMap<>();
 
-		HJSONDataBuilder visitor = new HJSONDataBuilder("Test:parsingWorksOnEmptyObject", startNode);
-		PropertyValue data = visitor.build();
-		assertThat(data).isNotNull();
-		assertThat(data.isLeaf()).isFalse();
-	}
+        HJSONDataBuilder visitor = new HJSONDataBuilder("Test:parsingWorksOnEmptyObject", startNode);
+        PropertyValue data = visitor.build();
+        assertThat(data).isNotNull();
+        assertThat(data.isLeaf()).isFalse();
+    }
 
-	@Test
-	public void arrayInObject() {
-		JsonObject startNode = new JsonObject().
-				add("arrayKey", new JsonArray());
-		HJSONDataBuilder visitor = new HJSONDataBuilder("Test:array", startNode);
-		PropertyValue data = visitor.build();
-		assertThat(data).isNotNull();
-		System.out.println(data.asString());
-	}
+    @Test
+    public void arrayInObject() {
+        JsonObject startNode = new JsonObject().
+                add("arrayKey", new JsonArray());
+        HJSONDataBuilder visitor = new HJSONDataBuilder("Test:array", startNode);
+        PropertyValue data = visitor.build();
+        assertThat(data).isNotNull();
+        System.out.println(data.asString());
+    }
 
-	@Test
-	public void array() {
-		JsonArray startNode = new JsonArray().
-				add(new JsonObject().add("k1", 1).add("k2", 2)).
-				add(new JsonObject().add("k1", 1).add("k2", 2)).
-				add(new JsonArray().add(new JsonObject().add("k31", "v31").add("k32", false)));
-		HJSONDataBuilder visitor = new HJSONDataBuilder("Test:array", startNode);
-		PropertyValue data = visitor.build();
-		assertThat(data).isNotNull();
-		System.out.println(data.asString());
-	}
+    @Test
+    public void array() {
+        JsonArray startNode = new JsonArray().
+                add(new JsonObject().add("k1", 1).add("k2", 2)).
+                add(new JsonObject().add("k1", 1).add("k2", 2)).
+                add(new JsonArray().add(new JsonObject().add("k31", "v31").add("k32", false)));
+        HJSONDataBuilder visitor = new HJSONDataBuilder("Test:array", startNode);
+        PropertyValue data = visitor.build();
+        assertThat(data).isNotNull();
+        System.out.println(data.asString());
+    }
 
 }

--- a/jodatime/src/test/java/org/apache/tamaya/jodatime/DateTimeConverterIT.java
+++ b/jodatime/src/test/java/org/apache/tamaya/jodatime/DateTimeConverterIT.java
@@ -20,7 +20,6 @@ package org.apache.tamaya.jodatime;
 
 
 import org.apache.tamaya.spi.PropertyConverter;
-import org.apache.tamaya.spi.ServiceContext;
 import org.apache.tamaya.spi.ServiceContextManager;
 import org.junit.Test;
 

--- a/jodatime/src/test/java/org/apache/tamaya/jodatime/DateTimeConverterTest.java
+++ b/jodatime/src/test/java/org/apache/tamaya/jodatime/DateTimeConverterTest.java
@@ -34,7 +34,7 @@ public class DateTimeConverterTest {
      */
     private static DateTimeConverter converter = new DateTimeConverter();
 
-    private static DateTimeFormatter FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
     @Test
     public void canConvertISO8601DateTimeSpecWithTimezoneOffset() {

--- a/jodatime/src/test/java/org/apache/tamaya/jodatime/DateTimeZoneConverterIT.java
+++ b/jodatime/src/test/java/org/apache/tamaya/jodatime/DateTimeZoneConverterIT.java
@@ -20,7 +20,6 @@ package org.apache.tamaya.jodatime;
 
 
 import org.apache.tamaya.spi.PropertyConverter;
-import org.apache.tamaya.spi.ServiceContext;
 import org.apache.tamaya.spi.ServiceContextManager;
 import org.junit.Test;
 

--- a/jodatime/src/test/java/org/apache/tamaya/jodatime/DateTimeZoneConverterTest.java
+++ b/jodatime/src/test/java/org/apache/tamaya/jodatime/DateTimeZoneConverterTest.java
@@ -23,7 +23,6 @@ import org.apache.tamaya.spi.ConversionContext;
 import org.apache.tamaya.spi.ConversionContext.Builder;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jodatime/src/test/java/org/apache/tamaya/jodatime/DurationConverterTest.java
+++ b/jodatime/src/test/java/org/apache/tamaya/jodatime/DurationConverterTest.java
@@ -24,7 +24,6 @@ import org.joda.time.Duration;
 import org.joda.time.format.ISOPeriodFormat;
 import org.joda.time.format.PeriodFormatter;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,7 +36,7 @@ public class DurationConverterTest {
 
     private static DurationConverter converter = new DurationConverter();
 
-    private static PeriodFormatter FORMATTER = ISOPeriodFormat.standard();
+    private static final PeriodFormatter FORMATTER = ISOPeriodFormat.standard();
 
     @Test
     public void canConvertPropertiesInAllSupportedFormats() {

--- a/jodatime/src/test/java/org/apache/tamaya/jodatime/PeriodConverterTest.java
+++ b/jodatime/src/test/java/org/apache/tamaya/jodatime/PeriodConverterTest.java
@@ -24,7 +24,6 @@ import org.joda.time.Period;
 import org.joda.time.format.ISOPeriodFormat;
 import org.joda.time.format.PeriodFormatter;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,7 +35,7 @@ public class PeriodConverterTest {
 
     private static PeriodConverter converter = new PeriodConverter();
 
-    private static PeriodFormatter FORMATTER = ISOPeriodFormat.standard();
+    private static final PeriodFormatter FORMATTER = ISOPeriodFormat.standard();
 
     @Test
     public void canConvertPropertiesInAllSupportedFormats() {

--- a/management/src/test/java/org/apache/tamaya/management/internal/ManagedConfigTest.java
+++ b/management/src/test/java/org/apache/tamaya/management/internal/ManagedConfigTest.java
@@ -29,7 +29,7 @@ import java.lang.management.ManagementFactory;
 import java.util.Map;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by Anatole on 20.08.2015.

--- a/metamodel/src/test/java/org/apache/tamaya/metamodel/ext/IntegrationTest.java
+++ b/metamodel/src/test/java/org/apache/tamaya/metamodel/ext/IntegrationTest.java
@@ -31,8 +31,7 @@ import org.junit.Test;
 import java.net.URL;
 import java.util.List;
 
-import static junit.framework.TestCase.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 06.12.16.
@@ -64,155 +63,140 @@ public class IntegrationTest {
     @Test
     public void testMetaContextConfig(){
         Configuration config = MetaConfiguration.createConfiguration(getConfig("IntegrationTests/context-test.xml"));
-        assertNotNull(config);
-        assertTrue(config.getProperties().isEmpty());
-        assertTrue(config.getContext().getPropertyConverters().isEmpty());
-        assertTrue(config.getContext().getPropertyFilters().isEmpty());
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isEmpty();
+        assertThat(config.getContext().getPropertyConverters()).isEmpty();
+        assertThat(config.getContext().getPropertyFilters()).isEmpty();
         MetaContext ctx = MetaContext.getInstance();
-        assertFalse(ctx.getProperties().isEmpty());
-        assertEquals(ctx.getId(), ctx.getProperty("_id"));
-        assertEquals("NONE", ctx.getProperty("app"));
-        assertEquals("DEV", ctx.getProperty("stage"));
-        assertEquals(".", ctx.getProperty("configdir"));
-
+        assertThat(ctx.getProperties()).isNotEmpty();
+        assertThat(ctx.getId()).isEqualTo(ctx.getProperty("_id"));
+        assertThat("NONE").isEqualTo(ctx.getProperty("app"));
+        assertThat("DEV").isEqualTo(ctx.getProperty("stage"));
+        assertThat(".").isEqualTo(ctx.getProperty("configdir"));
     }
 
     @Test
     public void testDefaultConvertersConfig(){
         Configuration config = MetaConfiguration.createConfiguration(getConfig("IntegrationTests/default-propertyconverters-test.xml"));
-        assertNotNull(config);
-        assertTrue(config.getContext().getPropertySources().isEmpty());
-        assertTrue(config.getProperties().isEmpty());
-        assertFalse(config.getContext().getPropertyConverters().isEmpty());
-        assertTrue(config.getContext().getPropertyFilters().isEmpty());
-        assertEquals(config,
-                Configuration.createConfigurationBuilder()
+        assertThat(config).isNotNull()
+            .isEqualTo(Configuration.createConfigurationBuilder()
                         .addDefaultPropertyConverters()
                         .build());
+        assertThat(config.getContext().getPropertySources()).isEmpty();
+        assertThat(config.getProperties()).isEmpty();
+        assertThat(config.getContext().getPropertyConverters()).isNotEmpty();
+        assertThat(config.getContext().getPropertyFilters()).isEmpty();
     }
 
     @Test
     public void testDefaultPropertySourcesConfig(){
         Configuration config = MetaConfiguration.createConfiguration(getConfig("IntegrationTests/default-propertysources-test.xml"));
-        assertNotNull(config);
-        assertFalse(config.getProperties().isEmpty());
-        assertFalse(config.getContext().getPropertySources().isEmpty());
-        assertTrue(config.getContext().getPropertyConverters().isEmpty());
-        assertTrue(config.getContext().getPropertyFilters().isEmpty());
-        assertEquals(config,
-                Configuration.createConfigurationBuilder()
-                        .addDefaultPropertySources()
-                        .build());
+        assertThat(config).isNotNull()
+            .isEqualTo(Configuration.createConfigurationBuilder()
+                    .addDefaultPropertySources().build());
+        assertThat(config.getProperties()).isNotEmpty();
+        assertThat(config.getContext().getPropertySources()).isNotEmpty();
+        assertThat(config.getContext().getPropertyConverters()).isEmpty();
+        assertThat(config.getContext().getPropertyFilters()).isEmpty();
     }
 
     @Test
     public void testDefaultPropertyFiltersConfig(){
         Configuration config = MetaConfiguration.createConfiguration(getConfig("IntegrationTests/default-propertyfilters-test.xml"));
-        assertNotNull(config);
-        assertTrue(config.getProperties().isEmpty());
-        assertTrue(config.getContext().getPropertySources().isEmpty());
-        assertTrue(config.getContext().getPropertyConverters().isEmpty());
-        assertFalse(config.getContext().getPropertyFilters().isEmpty());
-        assertEquals(config,
-                Configuration.createConfigurationBuilder()
-                        .addDefaultPropertyFilters()
-                        .build());
-
+        assertThat(config).isNotNull()
+            .isEqualTo(Configuration.createConfigurationBuilder()
+                        .addDefaultPropertyFilters().build());
+        assertThat(config.getProperties()).isEmpty();
+        assertThat(config.getContext().getPropertySources()).isEmpty();
+        assertThat(config.getContext().getPropertyConverters()).isEmpty();
+        assertThat(config.getContext().getPropertyFilters()).isNotEmpty();
     }
 
     @Test
     public void testPropertyFiltersConfig(){
         Configuration config = MetaConfiguration.createConfiguration(getConfig("IntegrationTests/propertyfilters-test.xml"));
-        assertNotNull(config);
-        assertTrue(config.getProperties().isEmpty());
-        assertTrue(config.getContext().getPropertySources().isEmpty());
-        assertTrue(config.getContext().getPropertyConverters().isEmpty());
-        assertFalse(config.getContext().getPropertyFilters().isEmpty());
-        assertEquals(1, config.getContext().getPropertyFilters().size());
-        assertTrue(config.getContext().getPropertyFilters().get(0) instanceof CachedFilter);
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isEmpty();
+        assertThat(config.getContext().getPropertySources()).isEmpty();
+        assertThat(config.getContext().getPropertyConverters()).isEmpty();
+        assertThat(config.getContext().getPropertyFilters()).isNotEmpty().hasSize(1);
+        assertThat(config.getContext().getPropertyFilters().get(0)).isInstanceOf(CachedFilter.class);
     }
 
     @Test
     public void testPropertyConvertersConfig(){
         Configuration config = MetaConfiguration.createConfiguration(getConfig("IntegrationTests/propertyconverters-test.xml"));
-        assertNotNull(config);
-        assertTrue(config.getProperties().isEmpty());
-        assertTrue(config.getContext().getPropertySources().isEmpty());
-        assertFalse(config.getContext().getPropertyConverters().isEmpty());
-        assertTrue(config.getContext().getPropertyFilters().isEmpty());
-        assertEquals(1, config.getContext().getPropertyConverters().size());
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isEmpty();
+        assertThat(config.getContext().getPropertySources()).isEmpty();
+        assertThat(config.getContext().getPropertyConverters()).isNotEmpty();
+        assertThat(config.getContext().getPropertyFilters()).isEmpty();
+        assertThat(config.getContext().getPropertyConverters()).hasSize(1);
         List<PropertyConverter<Object>> converters = config.getContext().getPropertyConverters(TypeLiteral.of(String.class));
-        assertTrue(converters.get(0).getClass().equals(MyConverter.class));
+        assertThat(converters.get(0)).isInstanceOf(MyConverter.class);
     }
 
     @Test
     public void testPropertySourcesConfig(){
         Configuration config = MetaConfiguration.createConfiguration(getConfig("IntegrationTests/propertysources-test.xml"));
-        assertNotNull(config);
-        assertFalse(config.getProperties().isEmpty());
-        assertFalse(config.getContext().getPropertySources().isEmpty());
-        assertTrue(config.getContext().getPropertyConverters().isEmpty());
-        assertTrue(config.getContext().getPropertyFilters().isEmpty());
-        assertEquals(2, config.getContext().getPropertySources().size());
-        assertTrue(config.getContext().getPropertySources().get(0) instanceof MyPropertySource);
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isNotEmpty();
+        assertThat(config.getContext().getPropertySources()).isNotEmpty().hasSize(2);
+        assertThat(config.getContext().getPropertyConverters()).isEmpty();
+        assertThat(config.getContext().getPropertyFilters()).isEmpty();
+        assertThat(config.getContext().getPropertySources().get(0)).isInstanceOf(MyPropertySource.class);
     }
 
     @Test
     public void testPropertyFilterConfig(){
         Configuration config = MetaConfiguration.createConfiguration(getConfig("IntegrationTests/propertyfilter-config-test.xml"));
-        assertNotNull(config);
-        assertTrue(config.getProperties().isEmpty());
-        assertTrue(config.getContext().getPropertySources().isEmpty());
-        assertTrue(config.getContext().getPropertyConverters().isEmpty());
-        assertFalse(config.getContext().getPropertyFilters().isEmpty());
-        assertEquals(1, config.getContext().getPropertyFilters().size());
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isEmpty();
+        assertThat(config.getContext().getPropertySources()).isEmpty();
+        assertThat(config.getContext().getPropertyConverters()).isEmpty();
+        assertThat(config.getContext().getPropertyFilters()).isNotEmpty().hasSize(1);
         PropertyFilter filter = config.getContext().getPropertyFilters().get(0);
-        assertNotNull(filter);
-        assertTrue(filter instanceof MyFilter);
+        assertThat(filter).isNotNull().isInstanceOf(MyFilter.class);
         MyFilter myFilter = (MyFilter)filter;
-        assertEquals("my-filter-name", myFilter.getName());
-        assertEquals("attrValue1", myFilter.getAttrValue());
-        assertEquals("elemValue1", myFilter.getElemValue());
-        assertEquals("overrideValue2", myFilter.getOverrideValue());
+        assertThat("my-filter-name").isEqualTo(myFilter.getName());
+        assertThat("attrValue1").isEqualTo(myFilter.getAttrValue());
+        assertThat("elemValue1").isEqualTo(myFilter.getElemValue());
+        assertThat("overrideValue2").isEqualTo(myFilter.getOverrideValue());
     }
 
     @Test
     public void testPropertySourceConfig(){
         Configuration config = MetaConfiguration.createConfiguration(getConfig("IntegrationTests/propertysource-config-test.xml"));
-        assertNotNull(config);
-        assertTrue(config.getProperties().isEmpty());
-        assertFalse(config.getContext().getPropertySources().isEmpty());
-        assertTrue(config.getContext().getPropertyConverters().isEmpty());
-        assertTrue(config.getContext().getPropertyFilters().isEmpty());
-        assertEquals(1, config.getContext().getPropertySources().size());
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isEmpty();
+        assertThat(config.getContext().getPropertySources()).isNotEmpty().hasSize(1);
+        assertThat(config.getContext().getPropertyConverters()).isEmpty();
+        assertThat(config.getContext().getPropertyFilters()).isEmpty();
         PropertySource ps = config.getContext().getPropertySources().get(0);
-        assertNotNull(ps);
-        assertTrue(ps instanceof MyPropertySource);
+        assertThat(ps).isNotNull().isInstanceOf(MyPropertySource.class);
         MyPropertySource mySource = (MyPropertySource)ps;
-        assertEquals("my-source-name", mySource.getName2());
-        assertEquals("attrValue1", mySource.getAttrValue());
-        assertEquals("elemValue1", mySource.getElemValue());
-        assertEquals("overrideValue2", mySource.getOverrideValue());
+        assertThat("my-source-name").isEqualTo(mySource.getName2());
+        assertThat("attrValue1").isEqualTo(mySource.getAttrValue());
+        assertThat("elemValue1").isEqualTo(mySource.getElemValue());
+        assertThat("overrideValue2").isEqualTo(mySource.getOverrideValue());
     }
 
     @Test
     public void testPropertyConverterConfig(){
         Configuration config = MetaConfiguration.createConfiguration(getConfig("IntegrationTests/propertyconverter-config-test.xml"));
-        assertNotNull(config);
-        assertTrue(config.getProperties().isEmpty());
-        assertTrue(config.getContext().getPropertySources().isEmpty());
-        assertFalse(config.getContext().getPropertyConverters().isEmpty());
-        assertTrue(config.getContext().getPropertyFilters().isEmpty());
-        assertEquals(1, config.getContext().getPropertyConverters().size());
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isEmpty();
+        assertThat(config.getContext().getPropertySources()).isEmpty();
+        assertThat(config.getContext().getPropertyConverters()).isNotEmpty().hasSize(1);
+        assertThat(config.getContext().getPropertyFilters()).isEmpty();
         PropertyConverter<?> converter = config.getContext().getPropertyConverters().values().iterator()
                 .next().get(0);
-        assertNotNull(converter);
-        assertTrue(converter instanceof MyConverter);
+        assertThat(converter).isNotNull().isInstanceOf(MyConverter.class);
         MyConverter myConverter = (MyConverter)converter;
-        assertEquals("my-converter-name", myConverter.getName());
-        assertEquals("attrValue1", myConverter.getAttrValue());
-        assertEquals("elemValue1", myConverter.getElemValue());
-        assertEquals("overrideValue2", myConverter.getOverrideValue());
+        assertThat("my-converter-name").isEqualTo(myConverter.getName());
+        assertThat("attrValue1").isEqualTo(myConverter.getAttrValue());
+        assertThat("elemValue1").isEqualTo(myConverter.getElemValue());
+        assertThat("overrideValue2").isEqualTo(myConverter.getOverrideValue());
     }
 
     private URL getConfig(String resource) {

--- a/metamodel/src/test/java/org/apache/tamaya/metamodel/internal/factories/ResourcePropertySourceProviderFactoryTest.java
+++ b/metamodel/src/test/java/org/apache/tamaya/metamodel/internal/factories/ResourcePropertySourceProviderFactoryTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tamaya.metamodel.internal.factories;
 
-import org.apache.tamaya.spi.PropertySource;
 import org.apache.tamaya.spi.PropertySourceProvider;
 import org.junit.Test;
 

--- a/metamodel/src/test/java/org/apache/tamaya/metamodel/internal/resolver/LoggingReader.java
+++ b/metamodel/src/test/java/org/apache/tamaya/metamodel/internal/resolver/LoggingReader.java
@@ -38,7 +38,7 @@ import java.util.TimerTask;
  */
 public class LoggingReader implements MetaConfigurationReader{
 
-    private static final JavaResolver resolver = new JavaResolver();
+    private static final JavaResolver RESOLVER = new JavaResolver();
 
     @Override
     public void read(final Document document, ConfigurationBuilder configBuilder) {
@@ -58,7 +58,7 @@ public class LoggingReader implements MetaConfigurationReader{
                         try {
                             line = reader.readLine();
                             while(line!=null){
-                                Object res = resolver.evaluate(line);
+                                Object res = RESOLVER.evaluate(line);
                                 if(res!=null) {
                                     System.out.println(res);
                                 }

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,8 @@ under the License.
                     </executions>
                     <configuration>
                         <logViolationsToConsole>true</logViolationsToConsole>
+                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                        <suppressionsLocation>buildtools/src/main/resources/checkstyle/suppressions.xml</suppressionsLocation>
                         <configLocation>buildtools/src/main/resources/checkstyle/style.xml</configLocation>
                     </configuration>
 

--- a/uom/src/test/java/org/apache/tamaya/uom/UnitConverterTest.java
+++ b/uom/src/test/java/org/apache/tamaya/uom/UnitConverterTest.java
@@ -29,16 +29,16 @@ import tec.units.ri.unit.Units;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class UnitConverterTest {
-	private UnitConverter converter = new UnitConverter();
+    private UnitConverter converter = new UnitConverter();
 
-	@Test
-	public void canConvertUnitInformation() {
+    @Test
+    public void canConvertUnitInformation() {
 
-		ConversionContext context = new ConversionContext.Builder(TypeLiteral.of(Unit.class)).build();
-		Unit<?> unit = converter.convert("m", context);
+        ConversionContext context = new ConversionContext.Builder(TypeLiteral.of(Unit.class)).build();
+        Unit<?> unit = converter.convert("m", context);
 
-		assertThat(unit).isNotNull();
-		assertThat(unit).isEqualTo(Units.METRE);
-	}
+        assertThat(unit).isNotNull();
+        assertThat(unit).isEqualTo(Units.METRE);
+    }
 
 }

--- a/vertx/src/test/java/org/apache/tamaya/vertx/ConfigVerticleTest.java
+++ b/vertx/src/test/java/org/apache/tamaya/vertx/ConfigVerticleTest.java
@@ -27,7 +27,6 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.tamaya.Configuration;
-import org.apache.tamaya.ConfigurationProvider;
 import org.apache.tamaya.functions.ConfigurationFunctions;
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,9 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Tests the Tamaya Vertx configuration support. Created by atsticks on

--- a/vertx/src/test/java/org/apache/tamaya/vertx/TestInjectedVerticle.java
+++ b/vertx/src/test/java/org/apache/tamaya/vertx/TestInjectedVerticle.java
@@ -20,21 +20,13 @@ package org.apache.tamaya.vertx;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
-import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageCodec;
-import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.Json;
-import org.apache.tamaya.Configuration;
-import org.apache.tamaya.ConfigurationProvider;
-import org.apache.tamaya.functions.ConfigurationFunctions;
-import org.apache.tamaya.functions.PropertyMatcher;
 import org.apache.tamaya.inject.api.Config;
 
 import java.math.BigDecimal;
-import java.util.Map;
 
 /**
  * Small configured verticle for testing Tamaya's vertx support.

--- a/vertx/src/test/java/org/apache/tamaya/vertx/TestInjectedVerticleTest.java
+++ b/vertx/src/test/java/org/apache/tamaya/vertx/TestInjectedVerticleTest.java
@@ -18,18 +18,12 @@
  */
 package org.apache.tamaya.vertx;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.tamaya.Configuration;
-import org.apache.tamaya.ConfigurationProvider;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
As in other cases, the changes here consist largely of the following:

* modify import statements
* convert tabs to spaces

There was also some lingering usage of JUnit test assertions in one of the metamodel test classes, which here gets replaced with AssertJ.