### PR TITLE
[Security] Do not use http to transfer artifacts

### DIFF
--- a/ui/base/pom.xml
+++ b/ui/base/pom.xml
@@ -143,7 +143,7 @@ under the License.
     <repositories>
         <repository>
             <id>vaadin-addons</id>
-            <url>http://maven.vaadin.com/vaadin-addons</url>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
         <repository>
             <id>vaadin-snapshots</id>


### PR DESCRIPTION
Following a mail thread via security team: Fixes:
CWE-829: Inclusion of Functionality from Untrusted Control Sphere
CWE-494: Download of Code Without Integrity Check