### PR TITLE
TAMAYA-387: Update checkstyle version

### DIFF
--- a/buildtools/src/main/resources/checkstyle/style.xml
+++ b/buildtools/src/main/resources/checkstyle/style.xml
@@ -20,7 +20,6 @@ under the License.
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
     "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
-    <module name="SuppressionCommentFilter"/>
 
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
@@ -35,8 +34,7 @@ under the License.
 
 
     <module name="TreeWalker">
-        <!-- needed for the SuppressionCommentFilter -->
-        <module name="FileContentsHolder"/>
+        <module name="SuppressionCommentFilter"/>
 
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->

--- a/pom.xml
+++ b/pom.xml
@@ -351,13 +351,7 @@ under the License.
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>7.8</version>
-                            <exclusions><!-- MCHECKSTYLE-156 -->
-                                <exclusion>
-                                    <groupId>com.sun</groupId>
-                                    <artifactId>tools</artifactId>
-                                </exclusion>
-                            </exclusions>
+                            <version>8.19</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
This updates the checkstyle (puppycrawl) version to the 8.x series,
adjusting the maven and style.xml configurations as appropriate.