### PR TITLE
TAMAYA-391 test for system properties that exist in all java versions

### DIFF
--- a/management/src/test/java/org/apache/tamaya/management/internal/ManagedConfigTest.java
+++ b/management/src/test/java/org/apache/tamaya/management/internal/ManagedConfigTest.java
@@ -82,7 +82,7 @@ public class ManagedConfigTest {
         assertThat(sections).isNotNull();
         assertThat(sections.contains("java")).isTrue();
         assertThat(sections.contains("sun")).isTrue();
-        assertThat(sections.contains("sun.os")).isTrue();
+        assertThat(sections.contains("sun.arch")).isTrue();
         assertThat(sections.size()).isGreaterThan(sectionsNT.size());
     }
 


### PR DESCRIPTION
Turns out openjdk 12 has changed the default value of "sun.os.patch.level". In java 11 and below, a missing value was replaced with the string "unknown". As of java 12, a missing value is null. There was a notice released for the equivalent change for "user.timezone" but not for "sun.os.patch.level". https://bugs.openjdk.java.net/browse/JDK-8213629

The change is visible here http://hg.openjdk.java.net/jdk/jdk/rev/b915bd68d907#l7.8