### PR TITLE
TAMAYA-410 bump camel-core version past CVE-2019-0188

### DIFF
--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -31,7 +31,7 @@ under the License.
     <packaging>jar</packaging>
 
     <properties>
-        <camel.version>2.17.6</camel.version>
+        <camel.version>2.24.0</camel.version>
     </properties>
 
     <build>


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2019-0188 , there's an XML injection bug in camel prior to 2.24.0.  This bumps us past the insecure version.  Good job Github on letting us know.